### PR TITLE
Fixed memory issue with WRRequestDownload under iOS7

### DIFF
--- a/WhiteRaccoon.m
+++ b/WhiteRaccoon.m
@@ -261,8 +261,7 @@ static NSMutableDictionary *folders;
 
 // delegate methods
 
--(void) requestCompleted:(WRRequest *) request
-{
+-(void) requestCompleted:(WRRequest *) request {
     [self.delegate requestCompleted:request];
     
     headRequest = headRequest.nextRequest;

--- a/WhiteRaccoon.m
+++ b/WhiteRaccoon.m
@@ -261,8 +261,8 @@ static NSMutableDictionary *folders;
 
 // delegate methods
 
--(void) requestCompleted:(WRRequest *) request {
-    
+-(void) requestCompleted:(WRRequest *) request
+{
     [self.delegate requestCompleted:request];
     
     headRequest = headRequest.nextRequest;
@@ -272,8 +272,6 @@ static NSMutableDictionary *folders;
     }else{
        [headRequest start]; 
     }
-    
-    
 }
 
 -(void) requestFailed:(WRRequest *) request{    
@@ -425,13 +423,8 @@ static NSMutableDictionary *folders;
             
             if (self.streamInfo.bytesConsumedThisIteration!=-1) {
                 if (self.streamInfo.bytesConsumedThisIteration!=0) {
-                    
-                    NSMutableData * recivedDataWithNewBytes = [self.receivedData mutableCopy];                    
-                    [recivedDataWithNewBytes appendBytes:self.streamInfo.buffer length:self.streamInfo.bytesConsumedThisIteration];
-                    
-                    self.receivedData = [NSData dataWithData:recivedDataWithNewBytes];
-                    
-                    
+                    NSMutableData *receivedMutableData = (NSMutableData *) self.receivedData;
+                    [receivedMutableData appendBytes:self.streamInfo.buffer length:self.streamInfo.bytesConsumedThisIteration];
                 }
             }else{
                 InfoLog(@"Stream opened, but failed while trying to read from it.");


### PR DESCRIPTION
Fixed issue which occurs when NSData is copied in WRRequestDownload
under iOS7 which led numerous calls to vm_allocate function. As a
result, application gets low memory warnings and finally gets
terminated. Looks like the true reason of this issue is a bug in iOS 7
SDK, and this workaround fixes it. It can't be reproduced in iOS 6 or earlier.
