### PR TITLE
Fixes directory listing parsing for large directories

### DIFF
--- a/WhiteRaccoon.m
+++ b/WhiteRaccoon.m
@@ -859,6 +859,12 @@ static NSMutableDictionary *folders;
 
 /*======================================================WRRequestListDir============================================================*/
 
+@interface WRRequestListDirectory ()
+
+@property (nonatomic, strong) NSMutableData * listData;
+
+@end
+
 @implementation WRRequestListDirectory
 @synthesize filesInfo;
 
@@ -885,6 +891,8 @@ static NSMutableDictionary *folders;
         return;
     }
     
+    self.listData = [NSMutableData data];
+
     // a little bit of C because I was not able to make NSInputStream play nice
     CFReadStreamRef readStreamRef = CFReadStreamCreateWithFTPURL(NULL, (__bridge CFURLRef)self.fullURL);
     self.streamInfo.readStream = (NSInputStream *)CFBridgingRelease(readStreamRef);
@@ -934,20 +942,26 @@ static NSMutableDictionary *folders;
                     NSUInteger  offset = 0;
                     CFIndex     parsedBytes;
                     
-                    do {        
+                    [self.listData appendBytes:self.streamInfo.buffer length:self.streamInfo.bytesConsumedThisIteration];
+                    
+                    do {
                         
                         CFDictionaryRef listingEntity = NULL;
                         
-                        parsedBytes = CFFTPCreateParsedResourceListing(NULL, &self.streamInfo.buffer[offset], self.streamInfo.bytesConsumedThisIteration - offset, &listingEntity);
+                        parsedBytes = CFFTPCreateParsedResourceListing(NULL, &((const uint8_t *) self.listData.bytes)[offset], self.listData.length - offset, &listingEntity);
                         
                         if (parsedBytes > 0) {
                             if (listingEntity != NULL) {            
                                 self.filesInfo = [self.filesInfo arrayByAddingObject:(NSDictionary *)CFBridgingRelease(listingEntity)];
                             }            
-                            offset += parsedBytes;            
+                            offset += (NSUInteger)parsedBytes;
                         }
                         
-                    } while (parsedBytes>0); 
+                    } while (parsedBytes > 0);
+
+                    if(offset != 0) {
+                        [self.listData replaceBytesInRange:NSMakeRange(0, offset) withBytes:NULL length:0];
+                    }
                 }
             }else{
                 InfoLog(@"Stream opened, but failed while trying to read from it.");


### PR DESCRIPTION
When listing a directory with several files, the information
will be available to the stream in multiple parts (by
multiple calls to the stream:handlEvent method). Sometimes this
information will be incomplete and won't be completely parsed.

If CFFTPCreateParsedResourceListing can't parse all the entries
in the listing, the remaining bytes in the buffer must be stored
to be parsed together when the stream has new bytes available.

This fixes #8 
